### PR TITLE
Fix minor login and Access errors

### DIFF
--- a/src/clientPages/Login/Login.js
+++ b/src/clientPages/Login/Login.js
@@ -13,7 +13,7 @@ function Login() {
         event.preventDefault();
 
 		axios.post(`${process.env.REACT_APP_API_URL}/api/clients/login`, {
-            email: event.target.email.value,
+            email: event.target.email.value.trim(),
             password: event.target.password.value
         })
 		.then((response) => {

--- a/src/components/TrainerAuth/TrainerAuth.js
+++ b/src/components/TrainerAuth/TrainerAuth.js
@@ -39,7 +39,7 @@ export function TrainerAuthorization(WrappedComponent) {
                 <main className="dashboard">
                     <p>You must be logged in to see this page.</p>
                     <p>
-                        <Link to="/login">Log in</Link>
+                        <Link to="/trainer/login">Log in</Link>
                     </p>
                 </main>
             );

--- a/src/trainerPages/TrainerLogin/TrainerLogin.js
+++ b/src/trainerPages/TrainerLogin/TrainerLogin.js
@@ -12,7 +12,7 @@ function TrainerLogin() {
         event.preventDefault();
 
 		axios.post(`${process.env.REACT_APP_API_URL}/api/trainers/login`, {
-            email: event.target.email.value,
+            email: event.target.email.value.trim(),
             password: event.target.password.value
         })
 		.then((response) => {

--- a/src/trainerPages/TrainerProfile/TrainerProfile.js
+++ b/src/trainerPages/TrainerProfile/TrainerProfile.js
@@ -27,7 +27,7 @@ function TrainerProfile ({user}){
 
 	const handleLogout = () => {
 		sessionStorage.removeItem("token");
-		navigate('/login');
+		navigate('/trainer/login');
 		
 	};
 


### PR DESCRIPTION
Make it so that a user can still login even if they accidently put spaces at the start or end of email and redirect trainers to trainer login page if they do not have access.